### PR TITLE
fix: export, highlight and ordered list style

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -206,6 +206,7 @@ ol,
 ul:not(#sidebar-files-menu,#context-menu,.outline-children) {
   padding-left: 2rem;
   line-height: 1;
+  font-size: 16px;
 }
 
 ol>li {
@@ -220,6 +221,11 @@ ol>li>ol>li>ol>li {
   list-style-type: lower-roman
 }
 
+@media print {
+  #write ol, ul {
+    line-height: 2;
+  }
+}
 /****** Table Style ******/
 
 table {
@@ -311,6 +317,7 @@ mark {
   background: #87CEFA;
   padding: 0 2px 0 2px;
   margin: 0 2px 0 2px;
+  border-radius: 3px;
 }
 
 h1 {


### PR DESCRIPTION
fix few problems as below:
1. export pdf unordered list and ordered list line height too small;
2. highlight looks too sharp, add border radius;
3. ordered list style type font too small;